### PR TITLE
add option for btfl.js to use tab on mobile (it will not be blocked)

### DIFF
--- a/app/design/frontend/base/default/template/gateway/form/gateway.phtml
+++ b/app/design/frontend/base/default/template/gateway/form/gateway.phtml
@@ -18,6 +18,7 @@ else
         StartCheckout.config({
             key: key,
             formLabel: 'Ok',
+            tabOnMobile: true,
             complete: function (params) {
                 submitFormWithToken(params); // params.token.id, params.email
             }


### PR DESCRIPTION
Beautiful.js now provides an option to open payment form in a tab instead of popup. Popup does not work well on mobile phones. Tabs very frequently are blocked by browser if they are created in async callbacks (ajax, timeouts, etc.). In our case we open tab in the same 'thread' where the click button event happens. So it should not be blocked by browser.